### PR TITLE
[DD-392] allow authorize with api key in swagger

### DIFF
--- a/ConversionTool/Startup.cs
+++ b/ConversionTool/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using System;
 
 namespace ConversionTool
 {
@@ -23,6 +24,26 @@ namespace ConversionTool
             services.AddControllers();
             services.AddSwaggerGen(c =>
             {
+                c.AddSecurityDefinition("Bearer",
+                    new OpenApiSecurityScheme
+                    {
+                        In = ParameterLocation.Header,
+                        Description = "Please enter the token into field as 'Bearer {token}'",
+                        Name = "Authorization",
+                        Type = SecuritySchemeType.ApiKey,
+                        Scheme = "Bearer"
+                    });
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                    {
+                        {
+                            new OpenApiSecurityScheme
+                            {
+                                Reference = new OpenApiReference { Id = "Bearer", Type = ReferenceType.SecurityScheme },
+                            },
+                            Array.Empty<string>()
+                        }
+                    });
+
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "ConversionTool", Version = "v1" });
 
                 var baseUrl = Configuration.GetValue<string>("BaseURL");


### PR DESCRIPTION
This PR is for activate the button `Authorize` in Swagger allowing indicate the token api key to use in endpoints that requiere authorization

Before:
![image](https://user-images.githubusercontent.com/355298/116149347-68f4d080-a6b8-11eb-8c8f-ed38104a7932.png)

Now:
![image](https://user-images.githubusercontent.com/355298/116149011-069bd000-a6b8-11eb-9c04-290bbe8ea003.png)
